### PR TITLE
First release

### DIFF
--- a/mitlib-export-revisions.php
+++ b/mitlib-export-revisions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Plugin Name: MITlib Export Revisions
+ * Description: A plugin to enable exporting of content revisions
+ * Version: 1.0.0
+ * Author: MIT Libraries
+ * License: GPL2
+ *
+ * @package MITlib Export Revisions
+ * @author MIT Libraries
+ */
+
+namespace Mitlib\ExportRevisions;
+
+// Don't call the file directly!
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enable exports of content revisions
+ *
+ * @param object $args This argument is unused.
+ */
+function export_revisions( $args ) {
+	global $wp_post_types;
+	$wp_post_types['revision']->can_export = true;
+}
+add_action( 'export_wp', 'Mitlib\ExportRevisions\export_revisions' );


### PR DESCRIPTION
This plugin has been deployed to the staging site, and confirmed to work there. I've got a branch of the new monorepo that adds it to the new infrastructure, in case we want to keep this moving forward.

### Background

The default behavior of the WordPress export tool only includes the current state of any content - past revisions are not included. However, during the migration project the UX staff has indicated that they still refer to these revisions at times. 

They asked us to investigate what would be required to include these revisions in the content transfer, and it turns out there's a pretty small piece of code needed - hence this plugin.

### Why these changes are being introduced

This adds the contents of the export plugin, so that they can go through some form of code review.

### How this addresses that need

This defines a simple `export_revisions()` function, which declares revisions as exportable. This adjustment is added as an action to the `export_wp` step, which allows for exports to include past revisions.

### Side effects of this change

Exported content is going to be larger now - potentially significantly for sites with a long history. For example, the 150 Books site export goes from 2.5 Mb to 7+ Mb when revisions are included.

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/LM-235
